### PR TITLE
Changed icons in table view and fixed spacing of copy/compare

### DIFF
--- a/lib/views/variant-view.dart
+++ b/lib/views/variant-view.dart
@@ -34,7 +34,7 @@ class _VariantView extends State<VariantView> {
             child: Row(
               children: [
                 Padding(
-                  padding: const EdgeInsets.only(right: 50),
+                  padding: const EdgeInsets.only(right: 20),
                   child: IconButton(
                     icon: const Icon(Icons.content_copy),
                     tooltip: "Copy selected variants to clipboard",
@@ -50,7 +50,8 @@ class _VariantView extends State<VariantView> {
                   padding: const EdgeInsets.only(right: 20),
                   child: ElevatedButton(
                       style: TextButton.styleFrom(
-                        textStyle: const TextStyle(fontSize: 20),
+                        textStyle: const TextStyle(fontSize: 18),
+                        backgroundColor: Colors.white
                       ),   //style
                       onPressed: () => launchUrl(Uri.parse('https://blast.ncbi.nlm.nih.gov/Blast.cgi?PROGRAM=blastn&PAGE_TYPE=BlastSearch&LINK_LOC=blasthome')),
                     child: const Text('Compare')
@@ -60,7 +61,6 @@ class _VariantView extends State<VariantView> {
               ]
             ),
           ),
-          //add Compare button right here
         ],
       ),
       body: const SortablePage(),
@@ -243,7 +243,7 @@ class _SortablePageState extends State<SortablePage> {
         Align(
           alignment: Alignment.centerRight,
           child: IconButton(
-            icon: user["selected"] ? const Icon(Icons.done_sharp): const Icon(Icons.do_disturb),
+            icon: user["selected"] ? const Icon(Icons.done_sharp): const Icon(Icons.check_box_outline_blank),
             color: const Color(0xff445756),
             onPressed: () {
               setState(() {
@@ -265,7 +265,7 @@ class _SortablePageState extends State<SortablePage> {
         Align(
           alignment: Alignment.centerRight,
           child: IconButton(
-            icon: user["pinned"] ? const Icon(Icons.push_pin): const Icon(Icons.panorama_fish_eye),
+            icon: user["pinned"] ? const Icon(Icons.push_pin): const Icon(Icons.push_pin_outlined),
             color: const Color(0xff445756),
             onPressed: () {
               setState(() {


### PR DESCRIPTION
Updated table view with some minor things - changed selection icon, made pin icon much more obvious, and fixed large spacing between copy and compare
<img width="1198" alt="Screen Shot 2022-10-09 at 10 11 59 PM" src="https://user-images.githubusercontent.com/46821194/194790861-5aa0f877-4933-4a65-99d7-77ddf8e61b71.png">
