### PR TITLE
Wrapped 'x' in Expanded to fix overflow on smaller screens (?)

### DIFF
--- a/lib/tabs/region.dart
+++ b/lib/tabs/region.dart
@@ -80,24 +80,26 @@ class _Window extends State<Window> {
                           widget.title, // widget.country["country"]
                           maxLines: 1,
                           style: const TextStyle(
-                              color: Colors.white, fontSize: 40),
+                              color: Colors.white, fontSize: 40.0),
                         ),
                       ),
-                      GestureDetector(
-                        child: const Icon(
-                          Icons.close,
-                          color: Colors.white,
-                        ),
-                        onTap: () {
-                          // TODO: add cleanup to home array
-                          setState(() {
-                            // need to handle cases where multiple cards?
-                            if (widget.body is RegionCard) {
-                              (widget.body as RegionCard).centerMap();
-                            }
-                            isClosed = true;
-                          });
-                        },
+                      Expanded(
+                        child: GestureDetector(
+                          child: const Icon(
+                            Icons.close,
+                            color: Colors.white,
+                          ),
+                          onTap: () {
+                            // TODO: add cleanup to home array
+                            setState(() {
+                              // need to handle cases where multiple cards?
+                              if (widget.body is RegionCard) {
+                                (widget.body as RegionCard).centerMap();
+                              }
+                              isClosed = true;
+                            });
+                          },
+                        )
                       )
                     ],
                   ),


### PR DESCRIPTION
Kept getting an error about some part of window overflowing - turned out that GestureDetector holding the 'Close' button for windows was the problem

This feels like more of a band-aid tho - probably want to auto size title if we are basing card size on window size - i.e. smaller screens get smaller cards but still size 40 title