### PR TITLE
Variants can now be pressed in table view to open variant card

### DIFF
--- a/lib/tabs/region.dart
+++ b/lib/tabs/region.dart
@@ -442,7 +442,7 @@ class _RegionCard extends State<RegionCard> {
                         builder: (context) => VariantView(
                           country: widget.country,
                           variants: variants,
-                          updateParent: (){print("implement this");},
+                          updateParent: widget.updateParent,
                         ))),
                 child: const Text(
                   "Further Info",

--- a/lib/views/variant-view.dart
+++ b/lib/views/variant-view.dart
@@ -3,6 +3,9 @@ import 'package:flutter/services.dart';
 import 'package:genome_2133/views/variant-card.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../home.dart';
+import '../tabs/region.dart';
+
 List selections = [];
 
 class VariantView extends StatefulWidget {
@@ -261,12 +264,17 @@ class _SortablePageState extends State<SortablePage> {
             alignment: Alignment.centerRight,
             child: Text(user["accession"].toString())
           ),
-          onTap: () async {
-            Navigator.pop(context, [
-              VariantCard(
-                  variant: user,
-              )
-            ]);
+          onTap: () {
+            Navigator.pop(context);
+            VariantCard selectedVariant = VariantCard(
+              variant: user,
+            );
+            windows.add(Window(
+              title: selectedVariant.toString(),
+              body: selectedVariant,
+              updateParent: widget.updateParent,
+            ));
+            widget.updateParent();
           }
         ));
 


### PR DESCRIPTION
Made the name of variants a button that can be pressed to open the corresponding variant card - same behavior as selecting variant from region card

May want to do something about windows list filling up over time