### PR TITLE
Closing an active card makes next card active/tap now changes map

### DIFF
--- a/lib/cards/continent.dart
+++ b/lib/cards/continent.dart
@@ -35,6 +35,17 @@ class ContinentCard extends StatefulWidget {
   void centerMap() {
     mapController.animateCamera(CameraUpdate.newLatLngZoom(_initMapCenter, 3.2));
   }
+
+  updateMap() async {
+    final String response = await rootBundle.loadString('assets/data.json');
+    final Map continents = await json.decode(response)["Continents"];
+    final Map continentMap = continents[continent];
+    mapController.animateCamera(CameraUpdate.newLatLngZoom(
+        LatLng(
+            continentMap["latitude"],
+            continentMap["longitude"]),
+        continentMap["zoom"]));
+  }
 }
 
 class _ContinentCard extends State<ContinentCard> {

--- a/lib/cards/country.dart
+++ b/lib/cards/country.dart
@@ -37,6 +37,15 @@ class CountryCard extends StatefulWidget {
   void centerMap() {
     mapController.animateCamera(CameraUpdate.newLatLngZoom(_initMapCenter, 3.2));
   }
+
+  updateMap() async {
+    mapController.animateCamera(CameraUpdate.newLatLngZoom(
+        LatLng(
+            country["latitude"],
+            country["longitude"] -
+                (-10.0 * country["zoom"] + 60)),
+        country["zoom"]));
+  }
 }
 
 Map<String, Widget> variantsCache = {};

--- a/lib/cards/skeleton.dart
+++ b/lib/cards/skeleton.dart
@@ -80,6 +80,12 @@ class _SkeletonCard extends State<SkeletonCard> {
         widget.updateParent();
       }
     });
+    if (widget.body is CountryCard) {
+      (widget.body as CountryCard).updateMap();
+    }
+    if (widget.body is ContinentCard) {
+      (widget.body as ContinentCard).updateMap();
+    }
     windows[windows.length - 2].controlKey.currentState!.updateState();
   }
 
@@ -268,10 +274,31 @@ class _SkeletonCard extends State<SkeletonCard> {
                                     // TODO: add cleanup to home array
                                     setState(() {
                                       // need to handle cases where multiple cards?
-                                      if (widget.body is CountryCard && windows.last == widget) {
-                                        (widget.body as CountryCard).centerMap();
-                                      } else if (widget.body is ContinentCard && windows.last == widget) {
-                                        (widget.body as ContinentCard).centerMap();
+                                      if (windows.length == 1) {
+                                        if (widget.body is CountryCard) {
+                                          (widget.body as CountryCard)
+                                              .centerMap();
+                                        } else
+                                        if (widget.body is ContinentCard) {
+                                          (widget.body as ContinentCard)
+                                              .centerMap();
+                                        }
+                                      } else {
+                                        if (windows.last == widget) {
+                                          SkeletonCard nextCard = windows[windows.length - 2];
+                                          List<SkeletonCard> temp = List.from(windows);
+                                          temp.remove(nextCard);
+                                          temp.add(nextCard);
+                                          windows = temp;
+                                          nextCard.updateParent();
+                                          if (nextCard.body is CountryCard) {
+                                            (nextCard.body as CountryCard).updateMap();
+                                          }
+                                          if (nextCard.body is ContinentCard) {
+                                            (nextCard.body as ContinentCard).updateMap();
+                                          }
+                                          nextCard.controlKey.currentState!.updateState();
+                                        }
                                       }
                                       isClosed = true;
                                     });


### PR DESCRIPTION
Added some code to make next card in list the active card upon closing active card - this will now also force map to update

Cards also change map on tap rather than having to drag

Note: feel like some of these lines are redundant but not entirely sure which ones are