### PR TITLE
Fix maps zoom offset for smaller countries

### DIFF
--- a/assets/data.json
+++ b/assets/data.json
@@ -1156,7 +1156,7 @@
       "numeric":970,
       "latitude":31.9,
       "longitude":35.2,
-      "zoom":5,
+      "zoom":7,
       "cca3":"PSE"
     },
     {

--- a/lib/cards/country.dart
+++ b/lib/cards/country.dart
@@ -46,7 +46,7 @@ class CountryCard extends StatefulWidget {
         LatLng(
             country["latitude"],
             country["longitude"] -
-                (-4.0 * country["zoom"] + 31.0)),
+                (-6.0 * country["zoom"] + 45.0)),
         country["zoom"].toDouble()));
   }
 }
@@ -59,12 +59,12 @@ class _CountryCard extends State<CountryCard> {
   _updateMap() async {
     if (isDesktop || isMapDisabled) return;
 
-    // zoom offset is based on ex. "zoom 7 -> shift 3 over" & "zoom 3 -> shift 19 over"
+    // zoom offset is based on ex. "zoom 7 -> shift 3 over" & "zoom 3 -> shift 27 over"
     mapController.animateCamera(CameraUpdate.newLatLngZoom(
         LatLng(
             widget.country["latitude"],
             widget.country["longitude"] -
-                (-4.0 * widget.country["zoom"] + 31.0)),
+                (-6.0 * widget.country["zoom"] + 45.0)),
         widget.country["zoom"].toDouble()));
   }
 

--- a/lib/cards/country.dart
+++ b/lib/cards/country.dart
@@ -46,7 +46,7 @@ class CountryCard extends StatefulWidget {
         LatLng(
             country["latitude"],
             country["longitude"] -
-                (-10.0 * country["zoom"] + 60)),
+                (-4.0 * country["zoom"] + 31.0)),
         country["zoom"].toDouble()));
   }
 }
@@ -59,11 +59,12 @@ class _CountryCard extends State<CountryCard> {
   _updateMap() async {
     if (isDesktop || isMapDisabled) return;
 
+    // zoom offset is based on ex. "zoom 7 -> shift 3 over" & "zoom 3 -> shift 19 over"
     mapController.animateCamera(CameraUpdate.newLatLngZoom(
         LatLng(
             widget.country["latitude"],
             widget.country["longitude"] -
-                (-10.0 * widget.country["zoom"] + 60)),
+                (-4.0 * widget.country["zoom"] + 31.0)),
         widget.country["zoom"].toDouble()));
   }
 


### PR DESCRIPTION
Maps were being offset too far right on smaller countries - added linear function for offset calculation

More zoomed out -> more offset
More zoomed in -> less offset

USA and West Bank used as primary examples